### PR TITLE
Sort upgrade list to ensure order of randomizer

### DIFF
--- a/SWD2Randomizer/Randomizer.cs
+++ b/SWD2Randomizer/Randomizer.cs
@@ -53,6 +53,8 @@ namespace SWD2Randomizer
                     upgrades.Add(upgrade);
                 }
             }
+            // Ensure order of upgrade
+            upgrades.Sort();
         }
 
         public int Randomize()


### PR DESCRIPTION
The Directory.GetFiles order is not guaranteed.
It caused seed to give different result on Linux using Mono.